### PR TITLE
Used the posture bar UI to show togglable status bars for every statu…

### DIFF
--- a/Config/PostureBarModConfig - StatusBars.ini
+++ b/Config/PostureBarModConfig - StatusBars.ini
@@ -1,0 +1,148 @@
+; NOTICE: this ini may be hot-reloaded at any time during gameplay by pressing the "RETURN" key
+; NOTICE: InGameScreenCoord are NOT resolution, but a system that game uses itself to later scale it to actual shown viewport, you should most likely not change those
+; ScreenPosition - set viewport position for generated bars, should be set to match top-left corner, AutoPositionSetup shall try to set it autamatically
+; GameToScreenScaling - scaling between game to screen viewports, should be set to match scale between InGameScreenCoord and shown screen , AutoGameToScreenScaling shall try to set it autamatically
+; AutoPositionSetup and AutoGameToScreenScaling - by default you want it to work by itself, if it won't work, try to activate OffsetTest to dedect values by yourself and turn off those options accordingly
+; NOTICE: When AutoPositionSetup and AutoGameToScreenScaling are true, values below are ignored
+[General]
+InGameScreenCoordWidth = 1920.0
+InGameScreenCoordHeight = 1080.0
+ScreenPositionX = 0.0
+ScreenPositionY = 0.0
+GameToScreenScaling = 1.0
+AutoPositionSetup = true
+AutoGameToScreenScaling = true
+
+; UseTextres - whenever mod should load textures instead of using UI style bars
+; FillFile - texture for bar fill, one that indicate current status of stagger/stamina
+; BorderFile - texture for bar border, one that serves as background for fill texture
+; FillOffset - offsets for fill texture, where it should be placed relative to border texture, currently you have to figure this numbers out
+[Textures]
+UseTextures = true
+BossBarFillFile = PostureBarResources\\BossBar.png
+BossBarBorderFile = PostureBarResources\\BossBarBorder.png
+EntityBarFillFile = PostureBarResources\\EntityBar.png
+EntityBarBorderFile = PostureBarResources\\EntityBarBorder.png
+BossFillTopLeftOffsetX = 34.0
+BossFillTopLeftOffsetY = 5.0
+BossFillBotRightOffsetX = -6.0
+BossFillBotRightOffsetY = -1.0
+EntityFillTopLeftOffsetX = 8.0
+EntityFillTopLeftOffsetY = 6.5
+EntityFillBotRightOffsetX = -8.0
+EntityFillBotRightOffsetY = -6.0
+
+; FillAlignment - from where should bar extend (0 - left, 1 - center, 2 - right)
+; FillType - how should bar fill work (0 - full to empty, 1 - empty to full)
+; FillResizeType - how should fill bar be resized due to stagger changes (0 - rect clip, 1 - scale)
+; Color of bars (red, green, blue, alpha), from 0 to 255. If you are using textures, it will only affect Fill Textures. Max/Min indicate color gradient between low and high amount of stagger/stamina
+[Style]
+FillAlignment = 0
+FillType = 0
+FillResizeType = 0
+StaggerColorMax = 255, 255, 0, 255
+StaggerColorMin = 255, 255, 0, 255
+StaminaColorMax = 63, 200, 87, 255
+StaminaColorMin = 63, 200, 87, 255
+
+; new universal bar height multiplier
+BarHeightMultiplier = 0.6
+
+; new status bar colors
+PoisonColorMax =  100, 250, 85, 255
+PoisonColorMin =  100, 250, 85, 255
+RotColorMax =     255, 127, 0, 255
+RotColorMin =     255, 127, 0, 255
+BleedColorMax =   255, 0, 0, 255
+BleedColorMin =   255, 0, 0, 255
+BlightColorMax =  255, 255, 0, 255
+BlightColorMin =  255, 255, 0, 255
+FrostColorMax =   40, 225, 255, 255
+FrostColorMin =   40, 225, 255, 255
+SleepColorMax =   240, 0, 200, 255
+SleepColorMin =   240, 0, 200, 255
+MadnessColorMax = 255, 255, 0, 255
+MadnessColorMin = 255, 255, 0, 255
+
+; DrawBars - whenever boss posture bars should be even drawn
+; UseStaminaForNPC - changes posture bar to stamina bar for all human characters, while they have stagger values, they do not use them at all
+; BarWidth and BarHeight - uses in game scaling (1920x1080)
+; ResetStaggerTotalTime - when enemy crosses 0 value of posture damage, they automatically restore it to full while getting posture broken, this value sets arbitrary time for animation of bar to load itself to full
+; FirstBossScreen - sets coords (in game scaling) of first boss posture bar, right now it is found by setting value til you are satisfied with it's location, use OffsetTest to help you with finding that offset
+; NextBossBarDiffScreenY - seets coords (in game scaling) for next boss bar Y wise (multiple boss fights)
+; NOTICE: Some mods can change this offset (like reforged), which means you will have to find it by yourself. Some popular offsets: Default (x: 957.5 y: 876), Reforged (x: 957.5 y: 958)
+[Boss Posture Bar]
+DrawBars = true
+UseStaminaForNPC = true
+BarWidth = 1020.0
+BarHeight = 16.0
+ResetStaggerTotalTime = 2.0
+FirstBossScreenX = 957.5
+FirstBossScreenY = 957.5
+NextBossBarDiffScreenY = 55.0
+
+; new status bar toggles
+DrawPoiseBar = true
+DrawPoisonBar = false
+DrawRotBar = false
+DrawBleedBar = true
+DrawBlightBar = true
+DrawFrostBar = false
+DrawSleepBar = false
+DrawMadnessBar = false
+
+; DrawBars - whenever entity posture bars should be even drawn
+; UseStaminaForNPC - changes posture bar to stamina bar for all human characters, while they have stagger values, they do not use them at all
+; BarWidth and BarHeight - uses in game scaling (1920x1080)
+; ResetStaggerTotalTime - when enemy crosses 0 value of posture damage, they automatically restore it to full while getting posture broken, this value sets arbitrary time for animation of bar to load itself to full
+; OffsetScreen - sets the offset (in game scaling) from enemy health bar position, you can use OffsetTest to adjust this position by yourself
+; ScreenThreshold - thresholds of where should posture bar stop in game viewport (in game scaling), most likely you should not change it
+[Entity Posture Bar]
+DrawBars = true
+UseStaminaForNPC = true
+BarWidth = 143.0
+BarHeight = 14.0
+ResetStaggerTotalTime = 2.0
+OffsetScreenX = -1.5
+OffsetScreenY = 5
+LeftScreenThreshold = 130.0
+RightScreenThreshold = 1790.0
+TopScreenThreshold = 175.0
+BottomScreenThreshold = 990.0
+
+; new status bar toggles
+DrawPoiseBar = true
+DrawPoisonBar = false
+DrawRotBar = false
+DrawBleedBar = true
+DrawBlightBar = true
+DrawFrostBar = false
+DrawSleepBar = false
+DrawMadnessBar = false
+
+; ADVANCED:
+; UsePositionFixing - position fixing algorithm, looks for previous positions to align posture bar better with health bar, by defalut they are slightly out of sync
+; PositionFixingMultiplier - multiplier by which bar movement velocity is affected, if bar is dragging behind hp bar then you have to increase this value, if it is going ahead of hp bar, then you have to decrease it
+UsePositionFixing = true
+PositionFixingMultiplierX = 10.0
+PositionFixingMultiplierY = 10.0
+
+; New stuff that I am not sure if they will work fine
+; HideBarsOnMenu - whenever mod should check for open menus, might not work perfectly all the time, but should be good enaugh
+[Experimental]
+HideBarsOnMenu = true
+
+; Player stagger bar - by default it will do nothing, as game does not use player stagger, use it only with mods that intends on making use of player stagger
+; I have not made any attempts at making it look/position good right now, reffer to mod author that intends on using such bar
+DrawBar = false
+BarWidth = 214.5f
+BarHeight = 21.0f
+ResetStaggerTotalTime = 2.0f
+ScreenX = 963.0f
+ScreenY = 50.0f
+
+; Log - log to file in mods/PostureModLog.txt
+; OffsetTest - creats in game menu for adjusting screen and bar offsets. Use "Insert" key to save currently modified offset to .ini. Use "Page up/down" keys to change which offset you want to modify. Use "Arrows" keys to modify values.
+[Debug]
+Log = false
+OffsetTest = false

--- a/Source/Main/Hooking.hpp
+++ b/Source/Main/Hooking.hpp
@@ -76,6 +76,7 @@ namespace ER
 			int frost;
 			int sleep;
 			int madness;
+
 			int poisonMax;
 			int rotMax;
 			int bleedMax;
@@ -83,6 +84,7 @@ namespace ER
 			int frostMax;
 			int sleepMax;
 			int madnessMax;
+
 			float poisonMod;
 			float rotMod;
 			float bleedMod;
@@ -90,6 +92,7 @@ namespace ER
 			float frostMod;
 			float sleepMod;
 			float madnessMod;
+
 			float poisonMul;
 			float rotMul;
 			float bleedMul;

--- a/Source/Main/PostureBarUI.cpp
+++ b/Source/Main/PostureBarUI.cpp
@@ -97,7 +97,7 @@ namespace ER
             Logger::log("Menu is open - not rendering bars", LogLevel::Debug);
             return;
         }
-
+        
         if (PlayerPostureBarData::drawBar)
         {
             if (auto playerPostureBar = playerBar; playerPostureBar)
@@ -106,7 +106,7 @@ namespace ER
 
                 float staggerRatio = playerPostureBar->stagger / playerPostureBar->maxStagger;
 
-                float height = PlayerPostureBarData::barHeight * ScreenParams::gameToViewportScaling;
+                float height = PlayerPostureBarData::barHeight * barHeightMultiplier * ScreenParams::gameToViewportScaling;
                 float width = PlayerPostureBarData::barWidth * ScreenParams::gameToViewportScaling;
                 ImVec2 positionOnViewport = ImVec2(PlayerPostureBarData::screenX, PlayerPostureBarData::screenY) * ScreenParams::gameToViewportScaling;
 
@@ -118,7 +118,7 @@ namespace ER
                 {
                     playerPostureBar->resetStaggerTimer -= std::chrono::duration_cast<std::chrono::duration<float>>(timePoint - playerPostureBar->lastTimePoint).count();
                     playerPostureBar->lastTimePoint = timePoint;
-
+                 
                     if (playerPostureBar->resetStaggerTimer <= 0.0f)
                         playerPostureBar->isResetStagger = false;
                     else
@@ -151,9 +151,17 @@ namespace ER
                 {
                     auto&& timePoint = std::chrono::steady_clock::now();
 
-                    float staggerRatio = bossPostureBar->stagger / bossPostureBar->maxStagger;
+					float staggerRatio = bossPostureBar->stagger / bossPostureBar->maxStagger;
 
-                    float height = BossPostureBarData::barHeight * ScreenParams::gameToViewportScaling;
+                    float poisonRatio = bossPostureBar->poison / bossPostureBar->maxPoison;
+                    float rotRatio = bossPostureBar->rot / bossPostureBar->maxRot;
+                    float bleedRatio = bossPostureBar->bleed / bossPostureBar->maxBleed;
+                    float blightRatio = bossPostureBar->blight / bossPostureBar->maxBlight;
+                    float frostRatio = bossPostureBar->frost / bossPostureBar->maxFrost;
+                    float sleepRatio = bossPostureBar->sleep / bossPostureBar->maxSleep;
+                    float madnessRatio = bossPostureBar->madness / bossPostureBar->maxMadness;
+
+                    float height = BossPostureBarData::barHeight * barHeightMultiplier * ScreenParams::gameToViewportScaling;
                     float width = BossPostureBarData::barWidth * ScreenParams::gameToViewportScaling;
                     ImVec2 viewportPosition = ImVec2(BossPostureBarData::firstBossScreenX, BossPostureBarData::firstBossScreenY) * ScreenParams::gameToViewportScaling;
 
@@ -178,20 +186,111 @@ namespace ER
                             auto barColor = getBarColor(bossPostureBar->isStamina, staggerRatio);
 
                             if (textureBarInit)
+                            {
                                 drawBar(bossBarTexture, barColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, timeRatio);
+                                viewportPosition.y += height;
+                            }
                             else
+                            {
                                 drawBar(barColor, viewportPosition, ImVec2(width, height), timeRatio);
-
-                            continue;
+                                viewportPosition.y += height;
+                            }
                         }
                     }
 
-                    auto barColor = getBarColor(bossPostureBar->isStamina, staggerRatio);
+                    auto staggerColor = getBarColor(bossPostureBar->isStamina, staggerRatio);
+
+                    auto poisonColor = mixBarColor(BarStyle::poisonMinColor, BarStyle::poisonMaxColor, poisonRatio);
+                    auto rotColor = mixBarColor(BarStyle::rotMinColor, BarStyle::rotMaxColor, rotRatio);
+                    auto bleedColor = mixBarColor(BarStyle::bleedMinColor, BarStyle::bleedMaxColor, bleedRatio);
+                    auto blightColor = mixBarColor(BarStyle::blightMinColor, BarStyle::blightMaxColor, blightRatio);
+                    auto frostColor = mixBarColor(BarStyle::frostMinColor, BarStyle::frostMaxColor, frostRatio);
+                    auto sleepColor = mixBarColor(BarStyle::sleepMinColor, BarStyle::sleepMaxColor, sleepRatio);
+                    auto madnessColor = mixBarColor(BarStyle::madnessMinColor, BarStyle::madnessMaxColor, madnessRatio);
 
                     if (textureBarInit)
-                        drawBar(bossBarTexture, barColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, staggerRatio);
-                    else
-                        drawBar(barColor, viewportPosition, ImVec2(width, height), staggerRatio);
+                    {
+                        if (bossPostureBar->drawPoiseBar && !bossPostureBar->isResetStagger) // Poise bar
+                        {
+							drawBar(bossBarTexture, staggerColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, staggerRatio);
+							viewportPosition.y += height;
+                        }
+                        if (bossPostureBar->drawPoisonBar) // Poison bar
+                        {
+							drawBar(bossBarTexture, poisonColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, poisonRatio);
+							viewportPosition.y += height;
+                        }
+                        if (bossPostureBar->drawRotBar) // Rot bar
+                        {
+							drawBar(bossBarTexture, rotColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, rotRatio);
+							viewportPosition.y += height;
+                        }
+                        if (bossPostureBar->drawBleedBar) // Bleed bar
+                        {
+							drawBar(bossBarTexture, bleedColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, bleedRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawBlightBar) // Blight bar
+                        {
+							drawBar(bossBarTexture, blightColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, blightRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawFrostBar) // Frost bar
+                        {
+							drawBar(bossBarTexture, frostColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, frostRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawSleepBar) // Sleep bar
+                        {
+							drawBar(bossBarTexture, sleepColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, sleepRatio);
+							viewportPosition.y += height;
+						}
+						if (bossPostureBar->drawMadnessBar) // Madness bar
+                        {
+							drawBar(bossBarTexture, madnessColor, viewportPosition, ImVec2(width, height), TextureData::bossOffset, madnessRatio);
+                        }
+                    }
+                    else {
+                        if (bossPostureBar->drawPoiseBar && !bossPostureBar->isResetStagger) // Poise bar
+                        {
+							drawBar(staggerColor, viewportPosition, ImVec2(width, height), staggerRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawPoisonBar) // Poison bar
+                        {
+							drawBar(poisonColor, viewportPosition, ImVec2(width, height), poisonRatio);
+                            viewportPosition.y += height;
+                        }
+                        if (bossPostureBar->drawRotBar) // Rot bar
+                        {
+                            drawBar(rotColor, viewportPosition, ImVec2(width, height), rotRatio);
+                            viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawBleedBar) // Bleed bar
+                        {
+							drawBar(bleedColor, viewportPosition, ImVec2(width, height), bleedRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawBlightBar) // Blight bar
+                        {
+							drawBar(blightColor, viewportPosition, ImVec2(width, height), blightRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawFrostBar) // Frost bar
+                        {
+							drawBar(frostColor, viewportPosition, ImVec2(width, height), frostRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawSleepBar) // Sleep bar
+                        {
+							drawBar(sleepColor, viewportPosition, ImVec2(width, height), sleepRatio);
+							viewportPosition.y += height;
+                        }
+						if (bossPostureBar->drawMadnessBar) // Madness bar
+                        {
+							drawBar(madnessColor, viewportPosition, ImVec2(width, height), madnessRatio);
+                        }
+                    }
                 }
 
         if (PostureBarData::drawBars)
@@ -201,6 +300,15 @@ namespace ER
                     auto&& timePoint = std::chrono::steady_clock::now();
 
                     float staggerRatio = postureBar->stagger / postureBar->maxStagger;
+
+					float poisonRatio = postureBar->poison / postureBar->maxPoison;
+					float rotRatio = postureBar->rot / postureBar->maxRot;
+					float bleedRatio = postureBar->bleed / postureBar->maxBleed;
+					float blightRatio = postureBar->blight / postureBar->maxBlight;
+					float frostRatio = postureBar->frost / postureBar->maxFrost;
+					float sleepRatio = postureBar->sleep / postureBar->maxSleep;
+					float madnessRatio = postureBar->madness / postureBar->maxMadness;
+
                     float distanceModifier = postureBar->distanceModifier;
 
                     ImVec2 gamePosition(postureBar->screenX, postureBar->screenY);
@@ -214,7 +322,7 @@ namespace ER
                     gamePosition.y = std::clamp(gamePosition.y, PostureBarData::topScreenThreshold, PostureBarData::bottomScreenThreshold);
 
                     // transform in game position into viewport position
-                    float height = PostureBarData::barHeight * ScreenParams::gameToViewportScaling;
+                    float height = PostureBarData::barHeight * barHeightMultiplier * ScreenParams::gameToViewportScaling;
                     float width = PostureBarData::barWidth * distanceModifier * ScreenParams::gameToViewportScaling;
                     ImVec2 viewportPosition = gamePosition * ScreenParams::gameToViewportScaling;
 
@@ -225,7 +333,7 @@ namespace ER
                     // apply user specified bar offset
                     viewportPosition.x += PostureBarData::offsetScreenX * ScreenParams::gameToViewportScaling;
                     viewportPosition.y += PostureBarData::offsetScreenY * ScreenParams::gameToViewportScaling;
-
+                    
                     if (postureBar->isResetStagger)
                     {
                         postureBar->resetStaggerTimer -= std::chrono::duration_cast<std::chrono::duration<float>>(timePoint - postureBar->lastTimePoint).count();
@@ -240,21 +348,114 @@ namespace ER
                             auto barColor = getBarColor(postureBar->isStamina, timeRatio);
 
                             if (textureBarInit)
+                            {
                                 drawBar(entityBarTexture, barColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, timeRatio);
+                                viewportPosition.y += height;
+                            }
                             else
+                            {
                                 drawBar(barColor, viewportPosition, ImVec2(width, height), timeRatio);
-
-                            continue;
+                                viewportPosition.y += height;
+                            }
                         }
                     }
 
-                    auto barColor = getBarColor(postureBar->isStamina, staggerRatio);
+                    auto staggerColor = getBarColor(postureBar->isStamina, staggerRatio);
 
-                    if (textureBarInit)
-                        drawBar(entityBarTexture, barColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, staggerRatio);
+					auto poisonColor = mixBarColor(BarStyle::poisonMinColor, BarStyle::poisonMaxColor, poisonRatio);
+					auto rotColor = mixBarColor(BarStyle::rotMinColor, BarStyle::rotMaxColor, rotRatio);
+					auto bleedColor = mixBarColor(BarStyle::bleedMinColor, BarStyle::bleedMaxColor, bleedRatio);
+					auto blightColor = mixBarColor(BarStyle::blightMinColor, BarStyle::blightMaxColor, blightRatio);
+					auto frostColor = mixBarColor(BarStyle::frostMinColor, BarStyle::frostMaxColor, frostRatio);
+					auto sleepColor = mixBarColor(BarStyle::sleepMinColor, BarStyle::sleepMaxColor, sleepRatio);
+					auto madnessColor = mixBarColor(BarStyle::madnessMinColor, BarStyle::madnessMaxColor, madnessRatio);
+
+                    if (textureBarInit) {
+                        if (postureBar->drawPoiseBar && !postureBar->isResetStagger) // Poise bar
+                        {
+							drawBar(entityBarTexture, staggerColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, staggerRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawPoisonBar) // Poison bar
+                        {
+							drawBar(entityBarTexture, poisonColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, poisonRatio);
+							viewportPosition.y += height;
+						}
+						if (postureBar->drawRotBar) // Rot bar
+                        {
+							drawBar(entityBarTexture, rotColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, rotRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawBleedBar) // Bleed bar
+                        {
+							drawBar(entityBarTexture, bleedColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, bleedRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawBlightBar) // Blight bar
+                        {
+							drawBar(entityBarTexture, blightColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, blightRatio);
+							viewportPosition.y += height;
+                        }
+                        if (postureBar->drawFrostBar) // Frost bar
+                        {
+							drawBar(entityBarTexture, frostColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, frostRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawSleepBar) // Sleep bar
+                        {
+							drawBar(entityBarTexture, sleepColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, sleepRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawMadnessBar) // Madness bar
+                        {
+							drawBar(entityBarTexture, madnessColor, viewportPosition, ImVec2(width, height), TextureData::entityOffset, madnessRatio);
+							viewportPosition.y += height;
+                        }
+                    }
                     else
-                        drawBar(barColor, viewportPosition, ImVec2(width, height), staggerRatio);
-                }
+                    {
+                        if (postureBar->drawPoiseBar && !postureBar->isResetStagger) // Poise bar
+                        {
+							drawBar(staggerColor, viewportPosition, ImVec2(width, height), staggerRatio);
+							viewportPosition.y += height;
+                        }
+                        if (postureBar->drawPoisonBar) // Poison bar
+                        {
+							drawBar(poisonColor, viewportPosition, ImVec2(width, height), poisonRatio);
+							viewportPosition.y += height;
+                        }
+                        if (postureBar->drawRotBar) // Rot bar
+                        {
+							drawBar(rotColor, viewportPosition, ImVec2(width, height), rotRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawBleedBar) // Bleed bar
+                        {
+							drawBar(bleedColor, viewportPosition, ImVec2(width, height), bleedRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawBlightBar) // Blight bar
+                        {
+							drawBar(blightColor, viewportPosition, ImVec2(width, height), blightRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawFrostBar) // Frost bar
+                        {
+							drawBar(frostColor, viewportPosition, ImVec2(width, height), frostRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawSleepBar) // Sleep bar
+                        {
+							drawBar(sleepColor, viewportPosition, ImVec2(width, height), sleepRatio);
+							viewportPosition.y += height;
+                        }
+						if (postureBar->drawMadnessBar) // Madness bar
+                        {
+							drawBar(madnessColor, viewportPosition, ImVec2(width, height), madnessRatio);
+							viewportPosition.y += height;
+                        }
+                    }
+                 }
     }
 
     ImColor PostureBarUI::getBarColor(bool isStamina, float fillRatio)
@@ -268,6 +469,16 @@ namespace ER
         int g = (int)std::lerp(colorFrom.y, colorTo.y, fillRatio);
         int b = (int)std::lerp(colorFrom.z, colorTo.z, fillRatio);
         int a = (int)std::lerp(colorFrom.w, colorTo.w, fillRatio);
+
+        return ImColor(r, g, b, a);
+    }
+
+    ImColor PostureBarUI::mixBarColor(ImVec4& minColor, ImVec4& maxColor, float fillRatio) {
+        fillRatio = 1.0f - fillRatio;
+        int r = (int)std::lerp(minColor.x, maxColor.x, fillRatio);
+        int g = (int)std::lerp(minColor.y, maxColor.y, fillRatio);
+        int b = (int)std::lerp(minColor.z, maxColor.z, fillRatio);
+        int a = (int)std::lerp(minColor.w, maxColor.w, fillRatio);
 
         return ImColor(r, g, b, a);
     }
@@ -405,34 +616,49 @@ namespace ER
 
                 auto&& timePoint = std::chrono::steady_clock::now();
 
-                BossPostureBarData bossStagerBarData;
+                BossPostureBarData bossStaggerBarData;
 
-                bossStagerBarData.entityHandle = entityHandle;
-                bossStagerBarData.displayId = feMan->bossHpBars[i].displayId;
-                bossStagerBarData.isStamina = BossPostureBarData::useStaminaForNPC && chrIns->modelNumber == 0;
-                bossStagerBarData.maxStagger = !bossStagerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->staggerMax : chrIns->chrModulelBag->statModule->staminaMax;
-                bossStagerBarData.stagger = !bossStagerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->stagger : chrIns->chrModulelBag->statModule->stamina;
-                bossStagerBarData.isVisible = chrIns->chrModulelBag->statModule->health > 0;
+                bossStaggerBarData.entityHandle = entityHandle;
+                bossStaggerBarData.displayId = feMan->bossHpBars[i].displayId;
+                bossStaggerBarData.isStamina = BossPostureBarData::useStaminaForNPC && chrIns->modelNumber == 0;
+                bossStaggerBarData.maxStagger = !bossStaggerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->staggerMax : chrIns->chrModulelBag->statModule->staminaMax;
+                bossStaggerBarData.stagger = !bossStaggerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->stagger : chrIns->chrModulelBag->statModule->stamina;
+                bossStaggerBarData.isVisible = chrIns->chrModulelBag->statModule->health > 0;
+
+				bossStaggerBarData.maxPoison = static_cast<float>(chrIns->chrModulelBag->resistanceModule->poisonMax);
+				bossStaggerBarData.poison = bossStaggerBarData.maxPoison - static_cast<float>(chrIns->chrModulelBag->resistanceModule->poison);
+				bossStaggerBarData.maxRot = static_cast<float>(chrIns->chrModulelBag->resistanceModule->rotMax);
+				bossStaggerBarData.rot = bossStaggerBarData.maxRot - static_cast<float>(chrIns->chrModulelBag->resistanceModule->rot);
+				bossStaggerBarData.maxBleed = static_cast<float>(chrIns->chrModulelBag->resistanceModule->bleedMax);
+				bossStaggerBarData.bleed = bossStaggerBarData.maxBleed - static_cast<float>(chrIns->chrModulelBag->resistanceModule->bleed);
+				bossStaggerBarData.maxBlight = static_cast<float>(chrIns->chrModulelBag->resistanceModule->blightMax);
+                bossStaggerBarData.blight = bossStaggerBarData.maxBlight - static_cast<float>(chrIns->chrModulelBag->resistanceModule->blight);
+                bossStaggerBarData.maxFrost = static_cast<float>(chrIns->chrModulelBag->resistanceModule->frostMax);
+                bossStaggerBarData.frost = bossStaggerBarData.maxFrost - static_cast<float>(chrIns->chrModulelBag->resistanceModule->frost);
+				bossStaggerBarData.maxSleep = static_cast<float>(chrIns->chrModulelBag->resistanceModule->sleepMax);
+				bossStaggerBarData.sleep = bossStaggerBarData.maxSleep - static_cast<float>(chrIns->chrModulelBag->resistanceModule->sleep);
+				bossStaggerBarData.maxMadness = static_cast<float>(chrIns->chrModulelBag->resistanceModule->madnessMax);
+				bossStaggerBarData.madness = bossStaggerBarData.maxMadness - static_cast<float>(chrIns->chrModulelBag->resistanceModule->madness);
 
                 if (previousBossStaggerBar && previousBossStaggerBar->entityHandle == entityHandle)
                 {
-                    if (!bossStagerBarData.isStamina && BossPostureBarData::resetStaggerTotalTime > 0.0f && previousBossStaggerBar->previousStagger <= 0.0f && bossStagerBarData.stagger == bossStagerBarData.maxStagger)
+                    if (!bossStaggerBarData.isStamina && BossPostureBarData::resetStaggerTotalTime > 0.0f && previousBossStaggerBar->previousStagger <= 0.0f && bossStaggerBarData.stagger == bossStaggerBarData.maxStagger)
                     {
-                        bossStagerBarData.isResetStagger = true;
-                        bossStagerBarData.resetStaggerTimer = BossPostureBarData::resetStaggerTotalTime;
-                        bossStagerBarData.lastTimePoint = timePoint;
+                        bossStaggerBarData.isResetStagger = true;
+                        bossStaggerBarData.resetStaggerTimer = BossPostureBarData::resetStaggerTotalTime;
+                        bossStaggerBarData.lastTimePoint = timePoint;
                     }
                     else
                     {
-                        bossStagerBarData.isResetStagger = previousBossStaggerBar->isResetStagger;
-                        bossStagerBarData.resetStaggerTimer = previousBossStaggerBar->resetStaggerTimer;
-                        bossStagerBarData.lastTimePoint = previousBossStaggerBar->lastTimePoint;
+                        bossStaggerBarData.isResetStagger = previousBossStaggerBar->isResetStagger;
+                        bossStaggerBarData.resetStaggerTimer = previousBossStaggerBar->resetStaggerTimer;
+                        bossStaggerBarData.lastTimePoint = previousBossStaggerBar->lastTimePoint;
                     }
 
-                    bossStagerBarData.previousStagger = bossStagerBarData.stagger;
+                    bossStaggerBarData.previousStagger = bossStaggerBarData.stagger;
                 }
 
-                g_postureUI->bossPostureBars[i] = bossStagerBarData;
+                g_postureUI->bossPostureBars[i] = bossStaggerBarData;
             }
             else
                 g_postureUI->bossPostureBars[i] = std::nullopt;
@@ -457,17 +683,31 @@ namespace ER
                 staggerBarData.entityHandle = entityHandle;
                 staggerBarData.isStamina = PostureBarData::useStaminaForNPC && chrIns->modelNumber == 0;
                 staggerBarData.maxStagger = !staggerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->staggerMax : chrIns->chrModulelBag->statModule->staminaMax;
-                staggerBarData.stagger = !staggerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->stagger : chrIns->chrModulelBag->statModule->stamina;
-                staggerBarData.screenX = feMan->entityHpBars[i].screenPosX;
+				staggerBarData.stagger = !staggerBarData.isStamina ? chrIns->chrModulelBag->staggerModule->stagger : chrIns->chrModulelBag->statModule->stamina;
+				staggerBarData.screenX = feMan->entityHpBars[i].screenPosX;
                 staggerBarData.screenY = feMan->entityHpBars[i].screenPosY;
                 staggerBarData.distanceModifier = feMan->entityHpBars[i].mod;
                 staggerBarData.isVisible = feMan->entityHpBars[i].isVisible && chrIns->chrModulelBag->statModule->health > 0;
+
+				staggerBarData.maxPoison = static_cast<float>(chrIns->chrModulelBag->resistanceModule->poisonMax);
+				staggerBarData.poison = staggerBarData.maxPoison - static_cast<float>(chrIns->chrModulelBag->resistanceModule->poison);
+				staggerBarData.maxRot = static_cast<float>(chrIns->chrModulelBag->resistanceModule->rotMax);
+				staggerBarData.rot = staggerBarData.maxRot - static_cast<float>(chrIns->chrModulelBag->resistanceModule->rot);
+				staggerBarData.maxBleed = static_cast<float>(chrIns->chrModulelBag->resistanceModule->bleedMax);
+				staggerBarData.bleed = staggerBarData.maxBleed - static_cast<float>(chrIns->chrModulelBag->resistanceModule->bleed);
+				staggerBarData.maxBlight = static_cast<float>(chrIns->chrModulelBag->resistanceModule->blightMax);
+				staggerBarData.blight = staggerBarData.maxBlight - static_cast<float>(chrIns->chrModulelBag->resistanceModule->blight);
+                staggerBarData.maxFrost = static_cast<float>(chrIns->chrModulelBag->resistanceModule->frostMax);
+                staggerBarData.frost = staggerBarData.maxFrost - static_cast<float>(chrIns->chrModulelBag->resistanceModule->frost);
+				staggerBarData.maxSleep = static_cast<float>(chrIns->chrModulelBag->resistanceModule->sleepMax);
+				staggerBarData.sleep = staggerBarData.maxSleep - static_cast<float>(chrIns->chrModulelBag->resistanceModule->sleep);
+				staggerBarData.maxMadness = static_cast<float>(chrIns->chrModulelBag->resistanceModule->madnessMax);
+				staggerBarData.madness = staggerBarData.maxMadness - static_cast<float>(chrIns->chrModulelBag->resistanceModule->madness);
 
                 staggerBarData.gameUiUpdateTimePoint = timePoint;
                 staggerBarData.gamePreviousUiUpdateTimePoint = timePoint;
                 staggerBarData.previousScreenX = staggerBarData.screenX;
                 staggerBarData.previousScreenY = staggerBarData.screenY;
-
 
                 if (previousStaggerBar && previousStaggerBar->entityHandle == entityHandle)
                 {

--- a/Source/Main/PostureBarUI.hpp
+++ b/Source/Main/PostureBarUI.hpp
@@ -28,8 +28,24 @@ namespace ER
 		int displayId = -1;
 		bool isStamina = false;
 		bool isVisible = false;
+
 		float maxStagger = 0.0f;
 		float stagger = 0.0f;
+
+		float maxPoison = 0.0f;
+		float poison = 0.0f;
+		float maxRot = 0.0f;
+		float rot = 0.0f;
+		float maxBleed = 0.0f;
+		float bleed = 0.0f;
+		float maxBlight = 0.0f;
+		float blight = 0.0f;
+		float maxFrost = 0.0f;
+		float frost = 0.0f;
+		float maxSleep = 0.0f;
+		float sleep = 0.0f;
+		float maxMadness = 0.0f;
+		float madness = 0.0f;
 
 		// Stagger reset
 		float previousStagger = 1.0f; // set to 1, as 0 would conflict with checking for posture break
@@ -45,6 +61,15 @@ namespace ER
 		static inline float firstBossScreenX = 963.0f;
 		static inline float firstBossScreenY = 945.0f;
 		static inline float nextBossBarDiffScreenY = 55.0f;
+
+		static inline bool drawPoiseBar =	true;
+		static inline bool drawPoisonBar =	true;
+		static inline bool drawRotBar =		true;
+		static inline bool drawBleedBar =	true;
+		static inline bool drawBlightBar =	true;
+		static inline bool drawFrostBar =	true;
+		static inline bool drawSleepBar =	true;
+		static inline bool drawMadnessBar = true;
 	};
 
 	struct PostureBarData
@@ -55,8 +80,24 @@ namespace ER
 		float screenY = 0.0f;
 		float distanceModifier = 0.0f;
 		bool isVisible = false;
+
 		float maxStagger = 0.0f;
 		float stagger = 0.0f;
+
+		float maxPoison = 0.0f;
+		float poison = 0.0f;
+		float maxRot = 0.0f;
+		float rot = 0.0f;
+		float maxBleed = 0.0f;
+		float bleed = 0.0f;
+		float maxBlight = 0.0f;
+		float blight = 0.0f;
+		float maxFrost = 0.0f;
+		float frost = 0.0f;
+		float maxSleep = 0.0f;
+		float sleep = 0.0f;
+		float maxMadness = 0.0f;
+		float madness = 0.0f;
 
 		// Position Fixing by movement velocity
 		float previousScreenX = -1.0f;
@@ -84,6 +125,15 @@ namespace ER
 		static inline bool  usePositionFixing = true;
 		static inline double positionFixingMultiplierX = 10.0f;
 		static inline double positionFixingMultiplierY = 10.0f;
+
+		static inline bool drawPoiseBar = true;
+		static inline bool drawPoisonBar = true;
+		static inline bool drawRotBar = true;
+		static inline bool drawBleedBar = true;
+		static inline bool drawBlightBar = true;
+		static inline bool drawFrostBar = true;
+		static inline bool drawSleepBar = true;
+		static inline bool drawMadnessBar = true;
 	};
 
 	struct ScreenParams
@@ -128,6 +178,21 @@ namespace ER
 		static inline ImVec4 staggerMinColor = { 255, 255, 0, 255 };
 		static inline ImVec4 staminaMaxColor = { 80, 200, 104, 255 };
 		static inline ImVec4 staminaMinColor = { 80, 200, 104, 255 };
+
+		static inline ImVec4 poisonMaxColor =  { 100, 250, 85, 255 };
+		static inline ImVec4 poisonMinColor =  { 100, 250, 85, 255 };
+		static inline ImVec4 rotMaxColor =     { 255, 127, 0, 255 };
+		static inline ImVec4 rotMinColor =     { 255, 127, 0, 255 };
+		static inline ImVec4 bleedMaxColor =   { 255, 0, 0, 255 }; 
+		static inline ImVec4 bleedMinColor =   { 255, 0, 0, 255 }; 
+		static inline ImVec4 blightMaxColor =  { 200, 200, 0, 255 };
+		static inline ImVec4 blightMinColor =  { 200, 200, 0, 255 };
+		static inline ImVec4 frostMaxColor =   { 40, 225, 255, 255 };
+		static inline ImVec4 frostMinColor =   { 40, 225, 255, 255 };
+		static inline ImVec4 sleepMaxColor =   { 240, 0, 200, 255 };
+		static inline ImVec4 sleepMinColor =   { 240, 0, 200, 255 };
+		static inline ImVec4 madnessMaxColor = { 255, 255, 0, 255 };
+		static inline ImVec4 madnessMinColor = { 255, 255, 0, 255 };
 	};
 
 	typedef std::pair<ImVec2 /* top-left */, ImVec2 /* bot-right*/> FillTextureOffset;
@@ -158,6 +223,7 @@ namespace ER
 		// Draws UI posture bars, use after starting imgui new frame
 		void Draw();
 		ImColor getBarColor(bool isStamina, float fillRatio);
+		ImColor mixBarColor(ImVec4& minColor, ImVec4& maxColor, float fillRatio);
 		void drawBar(const TextureBar& textureBar, const ImColor& color, const ImVec2& position, const ImVec2& size, const std::pair<ImVec2 /* top-left */, ImVec2 /* bot-right */>& fillOffset, float fillRatio);
 		void drawBar(const ImColor& color, const ImVec2& position, const ImVec2& size, float fillRatio);
 

--- a/Source/PostureBarMod.cpp
+++ b/Source/PostureBarMod.cpp
@@ -9,7 +9,7 @@ using namespace ER;
 
 bool loadIni()
 {
-    try
+    try    
     {
         using namespace mINI;
         INIFile config(dllPath + "PostureBarModConfig.ini");
@@ -72,6 +72,61 @@ bool loadIni()
         assert(staminaColorMin.size() == 4);
         BarStyle::staminaMinColor = ImVec4(std::stof(staminaColorMin[0]), std::stof(staminaColorMin[1]), std::stof(staminaColorMin[2]), std::stof(staminaColorMin[3]));
 
+		barHeightMultiplier = std::stof(ini["Style"].get("BarHeightMultiplier"));
+		assert(barHeightMultiplier > 0.f);
+
+		auto&& poisonColorMax = splitString(ini["Style"].get("PoisonColorMax"), ",");
+		assert(poisonColorMax.size() == 4);
+		BarStyle::poisonMaxColor = ImVec4(std::stof(poisonColorMax[0]), std::stof(poisonColorMax[1]), std::stof(poisonColorMax[2]), std::stof(poisonColorMax[3]));
+
+		auto&& poisonColorMin = splitString(ini["Style"].get("PoisonColorMin"), ",");
+		assert(poisonColorMin.size() == 4);
+		BarStyle::poisonMinColor = ImVec4(std::stof(poisonColorMin[0]), std::stof(poisonColorMin[1]), std::stof(poisonColorMin[2]), std::stof(poisonColorMin[3]));
+
+		auto&& rotColorMax = splitString(ini["Style"].get("RotColorMax"), ",");
+		assert(rotColorMax.size() == 4);
+		BarStyle::rotMaxColor = ImVec4(std::stof(rotColorMax[0]), std::stof(rotColorMax[1]), std::stof(rotColorMax[2]), std::stof(rotColorMax[3]));
+
+		auto&& rotColorMin = splitString(ini["Style"].get("RotColorMin"), ",");
+		assert(rotColorMin.size() == 4);
+		BarStyle::rotMinColor = ImVec4(std::stof(rotColorMin[0]), std::stof(rotColorMin[1]), std::stof(rotColorMin[2]), std::stof(rotColorMin[3]));
+
+		auto&& bleedColorMax = splitString(ini["Style"].get("BleedColorMax"), ",");
+		assert(bleedColorMax.size() == 4);
+		BarStyle::bleedMaxColor = ImVec4(std::stof(bleedColorMax[0]), std::stof(bleedColorMax[1]), std::stof(bleedColorMax[2]), std::stof(bleedColorMax[3]));
+
+		auto&& bleedColorMin = splitString(ini["Style"].get("BleedColorMin"), ",");
+		assert(bleedColorMin.size() == 4);
+		BarStyle::bleedMinColor = ImVec4(std::stof(bleedColorMin[0]), std::stof(bleedColorMin[1]), std::stof(bleedColorMin[2]), std::stof(bleedColorMin[3]));
+
+		auto&& blightColorMax = splitString(ini["Style"].get("BlightColorMax"), ",");
+		assert(blightColorMax.size() == 4);
+		BarStyle::blightMaxColor = ImVec4(std::stof(blightColorMax[0]), std::stof(blightColorMax[1]), std::stof(blightColorMax[2]), std::stof(blightColorMax[3]));
+
+		auto&& blightColorMin = splitString(ini["Style"].get("BlightColorMin"), ",");
+		assert(blightColorMin.size() == 4);
+		BarStyle::blightMinColor = ImVec4(std::stof(blightColorMin[0]), std::stof(blightColorMin[1]), std::stof(blightColorMin[2]), std::stof(blightColorMin[3]));
+
+		auto&& frostColorMax = splitString(ini["Style"].get("FrostColorMax"), ",");
+		assert(frostColorMax.size() == 4);
+		BarStyle::frostMaxColor = ImVec4(std::stof(frostColorMax[0]), std::stof(frostColorMax[1]), std::stof(frostColorMax[2]), std::stof(frostColorMax[3]));
+
+		auto&& frostColorMin = splitString(ini["Style"].get("FrostColorMin"), ",");
+		assert(frostColorMin.size() == 4);
+		BarStyle::frostMinColor = ImVec4(std::stof(frostColorMin[0]), std::stof(frostColorMin[1]), std::stof(frostColorMin[2]), std::stof(frostColorMin[3]));
+
+		auto&& sleepColorMax = splitString(ini["Style"].get("SleepColorMax"), ",");
+		assert(sleepColorMax.size() == 4);
+		BarStyle::sleepMaxColor = ImVec4(std::stof(sleepColorMax[0]), std::stof(sleepColorMax[1]), std::stof(sleepColorMax[2]), std::stof(sleepColorMax[3]));
+
+		auto&& sleepColorMin = splitString(ini["Style"].get("SleepColorMin"), ",");
+		assert(sleepColorMin.size() == 4);
+		BarStyle::sleepMinColor = ImVec4(std::stof(sleepColorMin[0]), std::stof(sleepColorMin[1]), std::stof(sleepColorMin[2]), std::stof(sleepColorMin[3]));
+
+		auto&& madnessColorMax = splitString(ini["Style"].get("MadnessColorMax"), ",");
+		assert(madnessColorMax.size() == 4);
+		BarStyle::madnessMaxColor = ImVec4(std::stof(madnessColorMax[0]), std::stof(madnessColorMax[1]), std::stof(madnessColorMax[2]), std::stof(madnessColorMax[3]));
+
         //-----------------------------------------------------------------------------------
         //									    Boss Posture Bar
         //-----------------------------------------------------------------------------------
@@ -83,6 +138,15 @@ bool loadIni()
         BossPostureBarData::firstBossScreenX = std::stof(ini["Boss Posture Bar"].get("FirstBossScreenX"));
         BossPostureBarData::firstBossScreenY = std::stof(ini["Boss Posture Bar"].get("FirstBossScreenY"));
         BossPostureBarData::nextBossBarDiffScreenY = std::stof(ini["Boss Posture Bar"].get("NextBossBarDiffScreenY"));
+
+		BossPostureBarData::drawPoiseBar = ini["Boss Posture Bar"].get("DrawPoiseBar") == "true";
+        BossPostureBarData::drawPoisonBar = ini["Boss Posture Bar"].get("DrawPoisonBar") == "true";
+		BossPostureBarData::drawRotBar = ini["Boss Posture Bar"].get("DrawRotBar") == "true";
+		BossPostureBarData::drawBleedBar = ini["Boss Posture Bar"].get("DrawBleedBar") == "true";
+		BossPostureBarData::drawBlightBar = ini["Boss Posture Bar"].get("DrawBlightBar") == "true";
+		BossPostureBarData::drawFrostBar = ini["Boss Posture Bar"].get("DrawFrostBar") == "true";
+		BossPostureBarData::drawSleepBar = ini["Boss Posture Bar"].get("DrawSleepBar") == "true";
+		BossPostureBarData::drawMadnessBar = ini["Boss Posture Bar"].get("DrawMadnessBar") == "true";
 
         //-----------------------------------------------------------------------------------
         //									    Entity Posture Bar
@@ -101,6 +165,15 @@ bool loadIni()
         PostureBarData::usePositionFixing = ini["Entity Posture Bar"].get("UsePositionFixing") == "true";
         PostureBarData::positionFixingMultiplierX = std::stof(ini["Entity Posture Bar"].get("PositionFixingMultiplierX"));
         PostureBarData::positionFixingMultiplierY = std::stof(ini["Entity Posture Bar"].get("PositionFixingMultiplierY"));
+
+		PostureBarData::drawPoiseBar = ini["Entity Posture Bar"].get("DrawPoiseBar") == "true";
+		PostureBarData::drawPoisonBar = ini["Entity Posture Bar"].get("DrawPoisonBar") == "true";
+		PostureBarData::drawRotBar = ini["Entity Posture Bar"].get("DrawRotBar") == "true";
+		PostureBarData::drawBleedBar = ini["Entity Posture Bar"].get("DrawBleedBar") == "true";
+		PostureBarData::drawBlightBar = ini["Entity Posture Bar"].get("DrawBlightBar") == "true";
+		PostureBarData::drawFrostBar = ini["Entity Posture Bar"].get("DrawFrostBar") == "true";
+		PostureBarData::drawSleepBar = ini["Entity Posture Bar"].get("DrawSleepBar") == "true";
+		PostureBarData::drawMadnessBar = ini["Entity Posture Bar"].get("DrawMadnessBar") == "true";
 
         //-----------------------------------------------------------------------------------
         //									    Experimental
@@ -360,6 +433,11 @@ void MainThread()
 
             if (moveVec.first != 0.f || moveVec.second != 0.f)
                 previousMoveVec = moveVec;
+        }
+
+        // reload ini settings for colors and bar toggles
+        if (GetAsyncKeyState(VK_RETURN)) {
+            loadIni();
         }
 
         std::this_thread::sleep_for(3ms);

--- a/Source/PostureBarMod.hpp
+++ b/Source/PostureBarMod.hpp
@@ -22,6 +22,7 @@ namespace ER
 	inline std::atomic_bool g_KillSwitch = FALSE;
 	inline bool offsetTesting = FALSE;
 	inline float offsetSpeed = 0.5f;
+	inline float barHeightMultiplier = 1.0f;
 	inline EDebugTestState debugState = EDebugTestState::GameScreenOffset;
 
 	inline std::string dllPath = "";


### PR DESCRIPTION
…s effect in the game in addition to the posture bar. Included associated INI fields and the ability to reload settings during gameplay.

- All 7 statuses and the posture bar now each have an INI field to toggle them for both normal enemies and bosses
- Each status also has two new INI fields for the min and max colors to blend
- Added a universal bar height multiplier INI field to control how tall each bar is; allows having multiple bars without excessive visual clutter
- Implemented INI hot-reloading when the "RETURN" key is pressed; useful to changing visible bars and colors while the game is running
- Included updated example INI; the new INI fields make this patch incompatible with old INIs unfortunately